### PR TITLE
Add support for enums

### DIFF
--- a/src/peakrdl_cheader/__peakrdl__.py
+++ b/src/peakrdl_cheader/__peakrdl__.py
@@ -53,6 +53,15 @@ class Exporter(ExporterSubcommandPlugin):
         )
 
         arg_group.add_argument(
+            "-e", "--generate-enums",
+            action="store_true",
+            default=False,
+            help="""
+            Enable generation of enum definitions.
+            """
+        )
+
+        arg_group.add_argument(
             "-x", "--explode-top",
             action="store_true",
             default=False,

--- a/src/peakrdl_cheader/design_state.py
+++ b/src/peakrdl_cheader/design_state.py
@@ -48,6 +48,9 @@ class DesignState:
         self.bitfield_order_ltoh: bool
         self.bitfield_order_ltoh = kwargs.pop("bitfield_order_ltoh", True)
 
+        self.generate_enums: bool
+        self.generate_enums = kwargs.pop("generate_enums", False)
+
         # If a register is wider than 64-bits, it cannot be represented by a stdint
         # type. Therefore it must be represented by an array of subwords
         self.wide_reg_subword_size: int


### PR DESCRIPTION
Adds an option `--generate-enums` to generate enum typedefs at the top of the header and use them in struct fields.

I didn't manage to run the tests so I haven't touched that part.