### PR TITLE
c_standards: Add a standard for linux driver programming

### DIFF
--- a/src/peakrdl_cheader/c_standards.py
+++ b/src/peakrdl_cheader/c_standards.py
@@ -7,6 +7,9 @@ class CStandard(enum.Enum):
         self.anon_unions = d.get("anon_unions", False)
         self.static_assert = d.get("static_assert", False)
         self.static_assert_needs_assert_h = d.get("static_assert_needs_assert_h", False)
+        self.static_assert_needs_build_bug_h = d.get("static_assert_needs_build_bug_h", False)
+        self.needs_stdint_h = d.get("needs_stdint_h", True)
+        self.needs_types_h = d.get("needs_types_h", False)
 
         # Prevent Enum from flattening members into aliases
         self._value_ = name
@@ -44,6 +47,15 @@ class CStandard(enum.Enum):
         "anon_unions": False,
         "static_assert": False,
         "static_assert_needs_assert_h": False,
+    }
+
+    linux = "linux", {
+        "anon_unions" : True,
+        "static_assert" :True,
+        "needs_stdint_h": False,
+        "needs_types_h" :True,
+        "static_assert_needs_assert_h" : False,
+        "static_assert_needs_build_bug_h": True,
     }
 
     latest = gnu17 # gnu23 is still unreleased

--- a/src/peakrdl_cheader/templates/header.h
+++ b/src/peakrdl_cheader/templates/header.h
@@ -8,7 +8,15 @@
 extern "C" {
 #endif
 
+{%- if ds.std.needs_stdint_h %}
 #include <stdint.h>
+{%- endif %}
+{%- if ds.std.needs_types_h %}
+#include <linux/types.h>
+{%- endif %}
 {%- if ds.std.static_assert_needs_assert_h %}
 #include <assert.h>
+{%- endif %}
+{%- if ds.std.static_assert_needs_build_bug_h %}
+#include <linux/build_bug.h>
 {%- endif %}


### PR DESCRIPTION
Linux kernel code does not have stdint or assert header files. 

The integer types used are included by default in Linux and compile time asserts are included in the build_bug.h header file.